### PR TITLE
fix: implement selector resolution for delete (prefix + name match)

### DIFF
--- a/skills/sessions/scripts/list_sessions.py
+++ b/skills/sessions/scripts/list_sessions.py
@@ -183,6 +183,47 @@ def discover(project: str) -> list[Session]:
     return sorted(sessions, key=lambda s: s.mtime, reverse=True)
 
 
+def _rewrite_history(uuids_to_remove: set[str]) -> None:
+    """Drop history.jsonl lines whose sessionId is in `uuids_to_remove`."""
+    history = CLAUDE_DIR / "history.jsonl"
+    if not history.exists() or not uuids_to_remove: return
+    lines = history.read_text().splitlines()
+    keep  = [line for line in lines if line.strip() and json.loads(line).get("sessionId") not in uuids_to_remove]
+    history.write_text("\n".join(keep) + "\n")
+
+
+def _delete_session(session: Session, project: str, rewrite_history: bool = True) -> bool:
+    """Delete one resolved session's files. Returns True on success.
+
+    When called from `prune`, set `rewrite_history=False` and have the caller
+    invoke `_rewrite_history` once with the full set of deleted UUIDs — that
+    keeps prune at O(N) instead of O(N²) on history rewrites.
+    """
+    uuid = session.uuid
+
+    if uuid in _active_session_ids():
+        print(f"ERROR: Session {uuid[:8]} is currently active")
+        return False
+
+    root    = project_dir(project)
+    targets = [p for p in [
+        root / f"{uuid}.jsonl" if root else None,
+        root / uuid if root else None,
+        CLAUDE_DIR / "file-history" / uuid,
+        CLAUDE_DIR / "session-env"  / uuid,
+    ] if p and p.exists()]
+
+    if not targets:
+        print(f"No session found: {uuid}")
+        return False
+
+    for path in targets: _remove(path)
+    if rewrite_history: _rewrite_history({uuid})
+
+    print(f"Deleted: {uuid[:8]} ({len(targets)} items)")
+    return True
+
+
 def delete(selector: str, project: str) -> None:
     sessions = discover(project)
     match, candidates = _resolve(selector, sessions)
@@ -200,33 +241,7 @@ def delete(selector: str, project: str) -> None:
         print("\nRefusing to delete. Use a more specific selector.")
         return
 
-    uuid = match.uuid
-
-    if uuid in _active_session_ids():
-        print(f"ERROR: Session {uuid[:8]} is currently active")
-        return
-
-    root    = project_dir(project)
-    targets = [p for p in [
-        root / f"{uuid}.jsonl" if root else None,
-        root / uuid if root else None,
-        CLAUDE_DIR / "file-history" / uuid,
-        CLAUDE_DIR / "session-env"  / uuid,
-    ] if p and p.exists()]
-
-    if not targets:
-        print(f"No session found: {uuid}")
-        return
-
-    for path in targets: _remove(path)
-
-    history = CLAUDE_DIR / "history.jsonl"
-    if history.exists():
-        lines = history.read_text().splitlines()
-        keep  = [line for line in lines if line.strip() and json.loads(line).get("sessionId") != uuid]
-        history.write_text("\n".join(keep) + "\n")
-
-    print(f"Deleted: {uuid[:8]} ({len(targets)} items)")
+    _delete_session(match, project)
 
 
 def prune(project: str, max_age: str, confirm: bool = False) -> None:
@@ -249,8 +264,12 @@ def prune(project: str, max_age: str, confirm: bool = False) -> None:
         print(f"\n**{len(old)} sessions** ready to prune.")
         return
 
-    for s in old: delete(s.uuid, project)
-    print(f"\nPruned {len(old)} sessions.")
+    deleted = set()
+    for s in old:
+        if _delete_session(s, project, rewrite_history=False):
+            deleted.add(s.uuid)
+    _rewrite_history(deleted)
+    print(f"\nPruned {len(deleted)} sessions.")
 
 
 # ---------------------------------------------------------------------------

--- a/skills/sessions/scripts/list_sessions.py
+++ b/skills/sessions/scripts/list_sessions.py
@@ -112,6 +112,53 @@ class Session:
 
 
 # ---------------------------------------------------------------------------
+#  Selector resolution
+# ---------------------------------------------------------------------------
+
+def _resolve(selector: str, sessions: list[Session]) -> tuple[Session | None, list[Session]]:
+    """Resolve a selector to a single Session.
+
+    Priority chain:
+      1. Exact full-UUID match.
+      2. UUID prefix match (`startswith`).
+      3. Name match: case-insensitive token-AND substring — every
+         whitespace-separated token of the selector must appear as a
+         substring of the session name (case-folded).
+
+    Returns (match, candidates):
+      - (session, [session])   exactly one match
+      - (None, [s1, s2, ...])  ambiguous, multiple candidates
+      - (None, [])             no match
+    """
+    selector = selector.strip()
+    if not selector:
+        return None, []
+
+    for s in sessions:
+        if s.uuid == selector:
+            return s, [s]
+
+    prefix_hits = [s for s in sessions if s.uuid.startswith(selector)]
+    if len(prefix_hits) == 1:
+        return prefix_hits[0], prefix_hits
+    if len(prefix_hits) > 1:
+        return None, prefix_hits
+
+    tokens = selector.lower().split()
+    if tokens:
+        name_hits = [
+            s for s in sessions
+            if all(t in s.name.lower() for t in tokens)
+        ]
+        if len(name_hits) == 1:
+            return name_hits[0], name_hits
+        if len(name_hits) > 1:
+            return None, name_hits
+
+    return None, []
+
+
+# ---------------------------------------------------------------------------
 #  Operations
 # ---------------------------------------------------------------------------
 
@@ -136,7 +183,25 @@ def discover(project: str) -> list[Session]:
     return sorted(sessions, key=lambda s: s.mtime, reverse=True)
 
 
-def delete(uuid: str, project: str) -> None:
+def delete(selector: str, project: str) -> None:
+    sessions = discover(project)
+    match, candidates = _resolve(selector, sessions)
+
+    if match is None and not candidates:
+        print(f"No session found: {selector}")
+        return
+
+    if match is None:
+        print(f"Ambiguous selector '{selector}' matches {len(candidates)} sessions:\n")
+        print("| # | Name | UUID | Date |")
+        print("|---|------|------|------|")
+        for i, s in enumerate(candidates, 1):
+            print(f"| {i} | {s.name} | `{s.uuid[:8]}` | {s.date} |")
+        print("\nRefusing to delete. Use a more specific selector.")
+        return
+
+    uuid = match.uuid
+
     if uuid in _active_session_ids():
         print(f"ERROR: Session {uuid[:8]} is currently active")
         return

--- a/skills/sessions/tests/test_list_sessions.py
+++ b/skills/sessions/tests/test_list_sessions.py
@@ -226,5 +226,91 @@ class SelectorResolutionTests(unittest.TestCase):
         self.assertTrue(j2.exists(), "name match must not fire when UUID prefix matches")
 
 
+class PrunePerformanceTests(unittest.TestCase):
+    """Guard against O(N²) regressions in prune().
+
+    prune() must call discover() exactly once and rewrite history.jsonl
+    exactly once, regardless of how many sessions are pruned. Calling
+    delete() per iteration (which itself calls discover() and rewrites
+    history) would explode both costs.
+    """
+
+    def setUp(self):
+        import os
+        import time
+        self._os = os
+        self._time = time
+
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+        self.claude_dir = Path(self.tmp.name) / ".claude"
+        self.claude_dir.mkdir()
+        (self.claude_dir / "projects").mkdir()
+
+        self.project = "/imaginary/project/path"
+        encoded = "-imaginary-project-path"
+        self.project_root = self.claude_dir / "projects" / encoded
+        self.project_root.mkdir()
+
+        self._claude_patch = patch.object(
+            list_sessions, "CLAUDE_DIR", self.claude_dir,
+        )
+        self._claude_patch.start()
+        self.addCleanup(self._claude_patch.stop)
+
+        # Force the shutil fallback in _remove(); no real Trash interaction.
+        self._sp_patch = patch.object(
+            subprocess, "run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=1),
+        )
+        self._sp_patch.start()
+        self.addCleanup(self._sp_patch.stop)
+
+        # Three sessions, all 30 days old (well past any prune threshold).
+        old_time = self._time.time() - 30 * 86400
+        self.uuids = [
+            "aaaaaaaa-1111-1111-1111-111111111111",
+            "bbbbbbbb-2222-2222-2222-222222222222",
+            "cccccccc-3333-3333-3333-333333333333",
+        ]
+        for u in self.uuids:
+            j = _write_session(self.project_root, u)
+            self._os.utime(j, (old_time, old_time))
+
+        # Pre-populate history so the rewrite path actually runs.
+        history = self.claude_dir / "history.jsonl"
+        history.write_text("\n".join(
+            json.dumps({"project": self.project, "sessionId": u, "display": "x"})
+            for u in self.uuids
+        ) + "\n")
+
+    def _prune(self) -> None:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            list_sessions.prune(self.project, "1d", confirm=True)
+
+    def test_prune_calls_discover_only_once(self):
+        with patch.object(
+            list_sessions, "discover", wraps=list_sessions.discover,
+        ) as spy:
+            self._prune()
+            self.assertEqual(
+                spy.call_count, 1,
+                "prune() must call discover() exactly once, not per session",
+            )
+
+    def test_prune_rewrites_history_only_once(self):
+        with patch.object(
+            list_sessions, "_rewrite_history",
+            wraps=list_sessions._rewrite_history,
+        ) as spy:
+            self._prune()
+            self.assertEqual(
+                spy.call_count, 1,
+                "prune() must batch history rewrite into one call",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/skills/sessions/tests/test_list_sessions.py
+++ b/skills/sessions/tests/test_list_sessions.py
@@ -107,6 +107,124 @@ class SelectorResolutionTests(unittest.TestCase):
             "delete() with UUID prefix should remove the session",
         )
 
+    # ------------------------------------------------------------------
+    # Baseline: full-UUID match still works (regression guard).
+    # ------------------------------------------------------------------
+
+    def test_delete_by_full_uuid(self):
+        full = "abc12345-1111-2222-3333-444444444444"
+        jsonl = _write_session(self.project_root, full)
+        self._delete(full)
+        self.assertFalse(jsonl.exists())
+
+    # ------------------------------------------------------------------
+    # Name matching.
+    # ------------------------------------------------------------------
+
+    def test_delete_by_name_substring(self):
+        """README example: '/sessions delete fix auth middleware'."""
+        uuid = "11111111-aaaa-bbbb-cccc-000000000001"
+        jsonl = _write_session(
+            self.project_root, uuid, custom_title="Fix auth middleware",
+        )
+        self._delete("fix auth")
+        self.assertFalse(jsonl.exists())
+
+    def test_delete_by_name_tokens_out_of_order(self):
+        """All tokens must match, but order is irrelevant."""
+        uuid = "11111111-aaaa-bbbb-cccc-000000000002"
+        jsonl = _write_session(
+            self.project_root, uuid, custom_title="Authentication middleware fix",
+        )
+        self._delete("fix auth")
+        self.assertFalse(jsonl.exists())
+
+    def test_name_match_case_insensitive(self):
+        uuid = "11111111-aaaa-bbbb-cccc-000000000003"
+        jsonl = _write_session(
+            self.project_root, uuid, custom_title="Authenticate User",
+        )
+        self._delete("AUTH")
+        self.assertFalse(jsonl.exists())
+
+    # ------------------------------------------------------------------
+    # Ambiguity: refuse, don't pick.
+    # ------------------------------------------------------------------
+
+    def test_ambiguous_prefix_refuses(self):
+        a = _write_session(
+            self.project_root, "42f15ca9-aaaa-1111-2222-333333333333",
+        )
+        b = _write_session(
+            self.project_root, "42f15ca9-bbbb-4444-5555-666666666666",
+        )
+        out = self._delete("42f15ca9")
+        self.assertTrue(a.exists(), "ambiguous prefix must not delete")
+        self.assertTrue(b.exists(), "ambiguous prefix must not delete")
+        self.assertIn("Ambiguous", out)
+
+    def test_ambiguous_name_refuses(self):
+        a = _write_session(
+            self.project_root,
+            "aaaaaaaa-1111-1111-1111-111111111111",
+            custom_title="Fix auth bug",
+        )
+        b = _write_session(
+            self.project_root,
+            "bbbbbbbb-2222-2222-2222-222222222222",
+            custom_title="Investigate auth",
+        )
+        out = self._delete("auth")
+        self.assertTrue(a.exists(), "ambiguous name must not delete")
+        self.assertTrue(b.exists(), "ambiguous name must not delete")
+        self.assertIn("Ambiguous", out)
+
+    # ------------------------------------------------------------------
+    # Safety: active sessions, no-match.
+    # ------------------------------------------------------------------
+
+    def test_active_session_protected_via_prefix(self):
+        """Active-session protection survives prefix resolution."""
+        full = "deadbeef-1111-2222-3333-444444444444"
+        jsonl = _write_session(self.project_root, full)
+
+        sessions_dir = self.claude_dir / "sessions"
+        sessions_dir.mkdir()
+        (sessions_dir / "lock.json").write_text(
+            json.dumps({"sessionId": full}),
+        )
+
+        out = self._delete("deadbeef")
+        self.assertTrue(jsonl.exists())
+        self.assertIn("currently active", out)
+
+    def test_no_match(self):
+        _write_session(
+            self.project_root, "abc12345-1111-2222-3333-444444444444",
+        )
+        out = self._delete("xyzzy")
+        self.assertIn("No session found", out)
+
+    # ------------------------------------------------------------------
+    # Priority: UUID-prefix wins over name substring.
+    # ------------------------------------------------------------------
+
+    def test_uuid_prefix_priority_over_name(self):
+        """If selector is a valid UUID prefix, name match does not fire."""
+        # Session 1: UUID starts with "abc"
+        uuid_with_prefix = "abcdef00-1111-2222-3333-444444444444"
+        j1 = _write_session(self.project_root, uuid_with_prefix)
+        # Session 2: name contains "abc", UUID does not
+        uuid_with_name = "00000000-1111-2222-3333-555555555555"
+        j2 = _write_session(
+            self.project_root, uuid_with_name, custom_title="abc title",
+        )
+
+        self._delete("abc")
+
+        self.assertFalse(j1.exists(), "UUID-prefix match should win priority")
+        self.assertTrue(j2.exists(), "name match must not fire when UUID prefix matches")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/skills/sessions/tests/test_list_sessions.py
+++ b/skills/sessions/tests/test_list_sessions.py
@@ -1,0 +1,112 @@
+"""Tests for list_sessions.py — selector resolution behavior.
+
+The SKILL.md and README claim that `delete` supports prefix-UUID matching and
+fuzzy-name matching. These tests verify that contract.
+
+Run from the repo root:
+    python3 -m unittest discover -s skills/sessions/tests
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+
+# Load the script as a module so we can call its functions directly.
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "list_sessions.py"
+_spec = importlib.util.spec_from_file_location("list_sessions", _SCRIPT)
+list_sessions = importlib.util.module_from_spec(_spec)
+sys.modules["list_sessions"] = list_sessions
+_spec.loader.exec_module(list_sessions)
+
+
+def _write_session(
+    project_root: Path,
+    uuid: str,
+    custom_title: str | None = None,
+) -> Path:
+    """Create a fake session JSONL plus its sidecar directories."""
+    project_root.mkdir(parents=True, exist_ok=True)
+    jsonl = project_root / f"{uuid}.jsonl"
+
+    lines = []
+    if custom_title:
+        lines.append(json.dumps({
+            "type": "custom-title",
+            "customTitle": custom_title,
+        }))
+    else:
+        lines.append(json.dumps({"type": "user", "content": "hello"}))
+
+    jsonl.write_text("\n".join(lines) + "\n")
+    return jsonl
+
+
+class SelectorResolutionTests(unittest.TestCase):
+    """Verify delete() honors the selector contract documented in SKILL.md."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+        self.claude_dir = Path(self.tmp.name) / ".claude"
+        self.claude_dir.mkdir()
+        (self.claude_dir / "projects").mkdir()
+
+        self.project = "/imaginary/project/path"
+        # Mirrors list_sessions.project_dir() encoding.
+        encoded = "-imaginary-project-path"
+        self.project_root = self.claude_dir / "projects" / encoded
+        self.project_root.mkdir()
+
+        # Point the module at our temp tree.
+        self._claude_patch = patch.object(
+            list_sessions, "CLAUDE_DIR", self.claude_dir,
+        )
+        self._claude_patch.start()
+        self.addCleanup(self._claude_patch.stop)
+
+        # Force _remove()'s shutil fallback by making the trash subprocess
+        # "fail." This keeps tests hermetic — no real Trash interaction.
+        self._sp_patch = patch.object(
+            subprocess, "run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=1),
+        )
+        self._sp_patch.start()
+        self.addCleanup(self._sp_patch.stop)
+
+    def _delete(self, selector: str) -> str:
+        """Run delete() and capture stdout."""
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            list_sessions.delete(selector, self.project)
+        return buf.getvalue()
+
+    # ------------------------------------------------------------------
+    # The headline regression test — proves the SKILL.md claim.
+    # ------------------------------------------------------------------
+
+    def test_delete_by_uuid_prefix(self):
+        """SKILL.md: 'fuzzy name or prefix match'. README: 'delete by partial UUID'."""
+        full_uuid = "42f15ca9-2d23-4ee5-9ad8-17fc6c3637f2"
+        jsonl = _write_session(self.project_root, full_uuid)
+
+        self._delete("42f15ca9")
+
+        self.assertFalse(
+            jsonl.exists(),
+            "delete() with UUID prefix should remove the session",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`delete` accepts a selector that the docs claim supports prefix-UUID and fuzzy-name matching, but the implementation requires an exact full UUID. This PR adds the resolver to match the documented contract, then fixes a perf regression that the resolver introduced into `prune`.

## What the docs claim

- `SKILL.md:21`: "list first to identify the target UUID by **fuzzy name or prefix match**"
- `README.md:34`: `/sessions delete fix auth middleware` — "delete by name (fuzzy match)"
- `README.md:35`: `/sessions delete 064ddd26` — "delete by partial UUID"

## What the code does on master

`delete()` builds paths like `root / f"{uuid}.jsonl"` and treats the selector as a literal full UUID. Passing a prefix or name returns `No session found: <selector>`.

## The fix

A pure resolver `_resolve(selector, sessions) → (match, candidates)`:

1. Exact full-UUID match.
2. UUID prefix match.
3. Name match: case-insensitive, token-AND substring — every whitespace-separated token of the selector must appear as a substring of `session.name.lower()`.

When the selector matches exactly one session, `delete()` proceeds as before. When it matches more than one, `delete()` prints the candidates and refuses. Destructive actions should not silently disambiguate.

Active-session protection now fires on the resolved UUID, so an active session is protected even when matched by prefix or name.

## Perf fix (third commit)

The resolver required `delete()` to call `discover()`. `prune()` calls `delete()` in a loop, so pruning N sessions became O(N²) walks plus N full reads of `history.jsonl`. For a 50-session project with a 10 MB history that's ~500 MB of history reads and 2500 stat calls instead of ~50 of each.

The third commit factors out two helpers:

- `_delete_session(session, project, rewrite_history=True)` — takes an already-resolved Session, skips selector resolution.
- `_rewrite_history(uuids_to_remove)` — the file-rewrite side-effect, callable with a batch.

`delete()` is now a thin `_resolve` + `_delete_session` wrapper. `prune()` calls `_delete_session(..., rewrite_history=False)` per session, then `_rewrite_history(deleted)` once at the end. Prune count reflects actual successful deletions instead of pre-filter size.

Two new regression-guard tests assert `discover()` and `_rewrite_history()` are each called exactly once per `prune` invocation.

## Open design choices (happy to change)

- **Ambiguity policy: refuse, don't pick.** Alternative would be "pick most recent by mtime"; I think refuse is safer. Easy switch if you prefer the other policy.
- **Name match: token-AND substring.** Predictable and stdlib-only. `difflib.get_close_matches` was the other option but felt overkill for short session names — happy to revisit.
- **Priority: UUID prefix beats name substring.** If a selector is both a valid UUID prefix and a name substring, the UUID wins.

## Proof

Three commits structured to make the bugs verifiable:

1. `tests: add failing test for documented selector contract` — applied alone to master, this commit's test fails with `AssertionError: True is not false : delete() with UUID prefix should remove the session`.
2. `fix: implement selector resolution for delete` — fixes the test and adds nine more covering full UUID, prefix, name (single + multi-token, case-insensitive), both ambiguity paths, active-session protection via prefix, no-match, and priority.
3. `perf: extract _delete_session() and batch history rewrite in prune()` — refactor + two regression-guard tests for prune's O(N) discover/history behavior.

```
$ python3 -m unittest discover -s skills/sessions/tests
............
Ran 12 tests in 0.052s
OK
```

## Notes

- Tests use stdlib `unittest` to match the existing zero-deps posture.
- Tests use `unittest.mock.patch.object(list_sessions, 'CLAUDE_DIR', ...)` against a tempdir — no monkey-patching of public API needed.
- The `_remove()` Trash subprocess is mocked to return non-zero in tests so the `shutil` fallback runs hermetically.
- Adjacent observation, not addressed here: `_index_first_prompts()` at line 48 leaks the history.jsonl file handle (`for line in history.open():`). The test suite surfaces it as `ResourceWarning`. Happy to send a separate one-line PR if you'd like.