### PR TITLE
fix: atomic history rewrite + tighten _remove() path guard

### DIFF
--- a/skills/sessions/scripts/list_sessions.py
+++ b/skills/sessions/scripts/list_sessions.py
@@ -183,6 +183,47 @@ def discover(project: str) -> list[Session]:
     return sorted(sessions, key=lambda s: s.mtime, reverse=True)
 
 
+def _rewrite_history(uuids_to_remove: set[str]) -> None:
+    """Drop history.jsonl lines whose sessionId is in `uuids_to_remove`."""
+    history = CLAUDE_DIR / "history.jsonl"
+    if not history.exists() or not uuids_to_remove: return
+    lines = history.read_text().splitlines()
+    keep  = [line for line in lines if line.strip() and json.loads(line).get("sessionId") not in uuids_to_remove]
+    history.write_text("\n".join(keep) + "\n")
+
+
+def _delete_session(session: Session, project: str, rewrite_history: bool = True) -> bool:
+    """Delete one resolved session's files. Returns True on success.
+
+    When called from `prune`, set `rewrite_history=False` and have the caller
+    invoke `_rewrite_history` once with the full set of deleted UUIDs — that
+    keeps prune at O(N) instead of O(N²) on history rewrites.
+    """
+    uuid = session.uuid
+
+    if uuid in _active_session_ids():
+        print(f"ERROR: Session {uuid[:8]} is currently active")
+        return False
+
+    root    = project_dir(project)
+    targets = [p for p in [
+        root / f"{uuid}.jsonl" if root else None,
+        root / uuid if root else None,
+        CLAUDE_DIR / "file-history" / uuid,
+        CLAUDE_DIR / "session-env"  / uuid,
+    ] if p and p.exists()]
+
+    if not targets:
+        print(f"No session found: {uuid}")
+        return False
+
+    for path in targets: _remove(path)
+    if rewrite_history: _rewrite_history({uuid})
+
+    print(f"Deleted: {uuid[:8]} ({len(targets)} items)")
+    return True
+
+
 def delete(selector: str, project: str) -> None:
     sessions = discover(project)
     match, candidates = _resolve(selector, sessions)
@@ -200,33 +241,7 @@ def delete(selector: str, project: str) -> None:
         print("\nRefusing to delete. Use a more specific selector.")
         return
 
-    uuid = match.uuid
-
-    if uuid in _active_session_ids():
-        print(f"ERROR: Session {uuid[:8]} is currently active")
-        return
-
-    root    = project_dir(project)
-    targets = [p for p in [
-        root / f"{uuid}.jsonl" if root else None,
-        root / uuid if root else None,
-        CLAUDE_DIR / "file-history" / uuid,
-        CLAUDE_DIR / "session-env"  / uuid,
-    ] if p and p.exists()]
-
-    if not targets:
-        print(f"No session found: {uuid}")
-        return
-
-    for path in targets: _remove(path)
-
-    history = CLAUDE_DIR / "history.jsonl"
-    if history.exists():
-        lines = history.read_text().splitlines()
-        keep  = [line for line in lines if line.strip() and json.loads(line).get("sessionId") != uuid]
-        history.write_text("\n".join(keep) + "\n")
-
-    print(f"Deleted: {uuid[:8]} ({len(targets)} items)")
+    _delete_session(match, project)
 
 
 def prune(project: str, max_age: str, confirm: bool = False) -> None:
@@ -249,8 +264,12 @@ def prune(project: str, max_age: str, confirm: bool = False) -> None:
         print(f"\n**{len(old)} sessions** ready to prune.")
         return
 
-    for s in old: delete(s.uuid, project)
-    print(f"\nPruned {len(old)} sessions.")
+    deleted = set()
+    for s in old:
+        if _delete_session(s, project, rewrite_history=False):
+            deleted.add(s.uuid)
+    _rewrite_history(deleted)
+    print(f"\nPruned {len(deleted)} sessions.")
 
 
 # ---------------------------------------------------------------------------

--- a/skills/sessions/scripts/list_sessions.py
+++ b/skills/sessions/scripts/list_sessions.py
@@ -112,6 +112,53 @@ class Session:
 
 
 # ---------------------------------------------------------------------------
+#  Selector resolution
+# ---------------------------------------------------------------------------
+
+def _resolve(selector: str, sessions: list[Session]) -> tuple[Session | None, list[Session]]:
+    """Resolve a selector to a single Session.
+
+    Priority chain:
+      1. Exact full-UUID match.
+      2. UUID prefix match (`startswith`).
+      3. Name match: case-insensitive token-AND substring — every
+         whitespace-separated token of the selector must appear as a
+         substring of the session name (case-folded).
+
+    Returns (match, candidates):
+      - (session, [session])   exactly one match
+      - (None, [s1, s2, ...])  ambiguous, multiple candidates
+      - (None, [])             no match
+    """
+    selector = selector.strip()
+    if not selector:
+        return None, []
+
+    for s in sessions:
+        if s.uuid == selector:
+            return s, [s]
+
+    prefix_hits = [s for s in sessions if s.uuid.startswith(selector)]
+    if len(prefix_hits) == 1:
+        return prefix_hits[0], prefix_hits
+    if len(prefix_hits) > 1:
+        return None, prefix_hits
+
+    tokens = selector.lower().split()
+    if tokens:
+        name_hits = [
+            s for s in sessions
+            if all(t in s.name.lower() for t in tokens)
+        ]
+        if len(name_hits) == 1:
+            return name_hits[0], name_hits
+        if len(name_hits) > 1:
+            return None, name_hits
+
+    return None, []
+
+
+# ---------------------------------------------------------------------------
 #  Operations
 # ---------------------------------------------------------------------------
 
@@ -136,7 +183,25 @@ def discover(project: str) -> list[Session]:
     return sorted(sessions, key=lambda s: s.mtime, reverse=True)
 
 
-def delete(uuid: str, project: str) -> None:
+def delete(selector: str, project: str) -> None:
+    sessions = discover(project)
+    match, candidates = _resolve(selector, sessions)
+
+    if match is None and not candidates:
+        print(f"No session found: {selector}")
+        return
+
+    if match is None:
+        print(f"Ambiguous selector '{selector}' matches {len(candidates)} sessions:\n")
+        print("| # | Name | UUID | Date |")
+        print("|---|------|------|------|")
+        for i, s in enumerate(candidates, 1):
+            print(f"| {i} | {s.name} | `{s.uuid[:8]}` | {s.date} |")
+        print("\nRefusing to delete. Use a more specific selector.")
+        return
+
+    uuid = match.uuid
+
     if uuid in _active_session_ids():
         print(f"ERROR: Session {uuid[:8]} is currently active")
         return

--- a/skills/sessions/scripts/list_sessions.py
+++ b/skills/sessions/scripts/list_sessions.py
@@ -165,7 +165,8 @@ def _resolve(selector: str, sessions: list[Session]) -> tuple[Session | None, li
 
 def _remove(path: Path) -> None:
     """Trash where available, rm as fallback. Refuses paths outside ~/.claude/"""
-    if not str(path.resolve()).startswith(str(CLAUDE_DIR.resolve())): return
+    claude_root = str(CLAUDE_DIR.resolve()) + os.sep
+    if not str(path.resolve()).startswith(claude_root): return
 
     trash_cmd = {
         "Darwin": ["osascript", "-e", f'tell application "Finder" to delete POSIX file "{path}"'],

--- a/skills/sessions/scripts/list_sessions.py
+++ b/skills/sessions/scripts/list_sessions.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import platform
 import re
 import shutil
@@ -184,12 +185,19 @@ def discover(project: str) -> list[Session]:
 
 
 def _rewrite_history(uuids_to_remove: set[str]) -> None:
-    """Drop history.jsonl lines whose sessionId is in `uuids_to_remove`."""
+    """Drop history.jsonl lines whose sessionId is in `uuids_to_remove`.
+
+    Writes to a sibling .tmp path and atomically renames onto the target
+    so a concurrent writer (another Claude Code session appending to
+    history) cannot see a half-written file.
+    """
     history = CLAUDE_DIR / "history.jsonl"
     if not history.exists() or not uuids_to_remove: return
     lines = history.read_text().splitlines()
     keep  = [line for line in lines if line.strip() and json.loads(line).get("sessionId") not in uuids_to_remove]
-    history.write_text("\n".join(keep) + "\n")
+    tmp   = history.parent / (history.name + ".tmp")
+    tmp.write_text("\n".join(keep) + "\n")
+    os.replace(tmp, history)
 
 
 def _delete_session(session: Session, project: str, rewrite_history: bool = True) -> bool:

--- a/skills/sessions/tests/test_list_sessions.py
+++ b/skills/sessions/tests/test_list_sessions.py
@@ -226,5 +226,91 @@ class SelectorResolutionTests(unittest.TestCase):
         self.assertTrue(j2.exists(), "name match must not fire when UUID prefix matches")
 
 
+class PrunePerformanceTests(unittest.TestCase):
+    """Guard against O(N²) regressions in prune().
+
+    prune() must call discover() exactly once and rewrite history.jsonl
+    exactly once, regardless of how many sessions are pruned. Calling
+    delete() per iteration (which itself calls discover() and rewrites
+    history) would explode both costs.
+    """
+
+    def setUp(self):
+        import os
+        import time
+        self._os = os
+        self._time = time
+
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+        self.claude_dir = Path(self.tmp.name) / ".claude"
+        self.claude_dir.mkdir()
+        (self.claude_dir / "projects").mkdir()
+
+        self.project = "/imaginary/project/path"
+        encoded = "-imaginary-project-path"
+        self.project_root = self.claude_dir / "projects" / encoded
+        self.project_root.mkdir()
+
+        self._claude_patch = patch.object(
+            list_sessions, "CLAUDE_DIR", self.claude_dir,
+        )
+        self._claude_patch.start()
+        self.addCleanup(self._claude_patch.stop)
+
+        # Force the shutil fallback in _remove(); no real Trash interaction.
+        self._sp_patch = patch.object(
+            subprocess, "run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=1),
+        )
+        self._sp_patch.start()
+        self.addCleanup(self._sp_patch.stop)
+
+        # Three sessions, all 30 days old (well past any prune threshold).
+        old_time = self._time.time() - 30 * 86400
+        self.uuids = [
+            "aaaaaaaa-1111-1111-1111-111111111111",
+            "bbbbbbbb-2222-2222-2222-222222222222",
+            "cccccccc-3333-3333-3333-333333333333",
+        ]
+        for u in self.uuids:
+            j = _write_session(self.project_root, u)
+            self._os.utime(j, (old_time, old_time))
+
+        # Pre-populate history so the rewrite path actually runs.
+        history = self.claude_dir / "history.jsonl"
+        history.write_text("\n".join(
+            json.dumps({"project": self.project, "sessionId": u, "display": "x"})
+            for u in self.uuids
+        ) + "\n")
+
+    def _prune(self) -> None:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            list_sessions.prune(self.project, "1d", confirm=True)
+
+    def test_prune_calls_discover_only_once(self):
+        with patch.object(
+            list_sessions, "discover", wraps=list_sessions.discover,
+        ) as spy:
+            self._prune()
+            self.assertEqual(
+                spy.call_count, 1,
+                "prune() must call discover() exactly once, not per session",
+            )
+
+    def test_prune_rewrites_history_only_once(self):
+        with patch.object(
+            list_sessions, "_rewrite_history",
+            wraps=list_sessions._rewrite_history,
+        ) as spy:
+            self._prune()
+            self.assertEqual(
+                spy.call_count, 1,
+                "prune() must batch history rewrite into one call",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/skills/sessions/tests/test_list_sessions.py
+++ b/skills/sessions/tests/test_list_sessions.py
@@ -107,6 +107,124 @@ class SelectorResolutionTests(unittest.TestCase):
             "delete() with UUID prefix should remove the session",
         )
 
+    # ------------------------------------------------------------------
+    # Baseline: full-UUID match still works (regression guard).
+    # ------------------------------------------------------------------
+
+    def test_delete_by_full_uuid(self):
+        full = "abc12345-1111-2222-3333-444444444444"
+        jsonl = _write_session(self.project_root, full)
+        self._delete(full)
+        self.assertFalse(jsonl.exists())
+
+    # ------------------------------------------------------------------
+    # Name matching.
+    # ------------------------------------------------------------------
+
+    def test_delete_by_name_substring(self):
+        """README example: '/sessions delete fix auth middleware'."""
+        uuid = "11111111-aaaa-bbbb-cccc-000000000001"
+        jsonl = _write_session(
+            self.project_root, uuid, custom_title="Fix auth middleware",
+        )
+        self._delete("fix auth")
+        self.assertFalse(jsonl.exists())
+
+    def test_delete_by_name_tokens_out_of_order(self):
+        """All tokens must match, but order is irrelevant."""
+        uuid = "11111111-aaaa-bbbb-cccc-000000000002"
+        jsonl = _write_session(
+            self.project_root, uuid, custom_title="Authentication middleware fix",
+        )
+        self._delete("fix auth")
+        self.assertFalse(jsonl.exists())
+
+    def test_name_match_case_insensitive(self):
+        uuid = "11111111-aaaa-bbbb-cccc-000000000003"
+        jsonl = _write_session(
+            self.project_root, uuid, custom_title="Authenticate User",
+        )
+        self._delete("AUTH")
+        self.assertFalse(jsonl.exists())
+
+    # ------------------------------------------------------------------
+    # Ambiguity: refuse, don't pick.
+    # ------------------------------------------------------------------
+
+    def test_ambiguous_prefix_refuses(self):
+        a = _write_session(
+            self.project_root, "42f15ca9-aaaa-1111-2222-333333333333",
+        )
+        b = _write_session(
+            self.project_root, "42f15ca9-bbbb-4444-5555-666666666666",
+        )
+        out = self._delete("42f15ca9")
+        self.assertTrue(a.exists(), "ambiguous prefix must not delete")
+        self.assertTrue(b.exists(), "ambiguous prefix must not delete")
+        self.assertIn("Ambiguous", out)
+
+    def test_ambiguous_name_refuses(self):
+        a = _write_session(
+            self.project_root,
+            "aaaaaaaa-1111-1111-1111-111111111111",
+            custom_title="Fix auth bug",
+        )
+        b = _write_session(
+            self.project_root,
+            "bbbbbbbb-2222-2222-2222-222222222222",
+            custom_title="Investigate auth",
+        )
+        out = self._delete("auth")
+        self.assertTrue(a.exists(), "ambiguous name must not delete")
+        self.assertTrue(b.exists(), "ambiguous name must not delete")
+        self.assertIn("Ambiguous", out)
+
+    # ------------------------------------------------------------------
+    # Safety: active sessions, no-match.
+    # ------------------------------------------------------------------
+
+    def test_active_session_protected_via_prefix(self):
+        """Active-session protection survives prefix resolution."""
+        full = "deadbeef-1111-2222-3333-444444444444"
+        jsonl = _write_session(self.project_root, full)
+
+        sessions_dir = self.claude_dir / "sessions"
+        sessions_dir.mkdir()
+        (sessions_dir / "lock.json").write_text(
+            json.dumps({"sessionId": full}),
+        )
+
+        out = self._delete("deadbeef")
+        self.assertTrue(jsonl.exists())
+        self.assertIn("currently active", out)
+
+    def test_no_match(self):
+        _write_session(
+            self.project_root, "abc12345-1111-2222-3333-444444444444",
+        )
+        out = self._delete("xyzzy")
+        self.assertIn("No session found", out)
+
+    # ------------------------------------------------------------------
+    # Priority: UUID-prefix wins over name substring.
+    # ------------------------------------------------------------------
+
+    def test_uuid_prefix_priority_over_name(self):
+        """If selector is a valid UUID prefix, name match does not fire."""
+        # Session 1: UUID starts with "abc"
+        uuid_with_prefix = "abcdef00-1111-2222-3333-444444444444"
+        j1 = _write_session(self.project_root, uuid_with_prefix)
+        # Session 2: name contains "abc", UUID does not
+        uuid_with_name = "00000000-1111-2222-3333-555555555555"
+        j2 = _write_session(
+            self.project_root, uuid_with_name, custom_title="abc title",
+        )
+
+        self._delete("abc")
+
+        self.assertFalse(j1.exists(), "UUID-prefix match should win priority")
+        self.assertTrue(j2.exists(), "name match must not fire when UUID prefix matches")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/skills/sessions/tests/test_list_sessions.py
+++ b/skills/sessions/tests/test_list_sessions.py
@@ -406,5 +406,39 @@ class SafetyTests(unittest.TestCase):
         self.assertIn(kept_uuid,    remaining)
         self.assertNotIn(deleted_uuid, remaining)
 
+    # ------------------------------------------------------------------
+    # _remove() path guard.
+    # ------------------------------------------------------------------
+
+    def test_remove_refuses_sibling_dir_with_prefix(self):
+        """`~/.claude-evil/x` shares a string prefix with `~/.claude` but
+        is NOT inside it. The guard must reject it. Without the os.sep
+        fix, this slips through because startswith() is prefix-string,
+        not path-containment."""
+        evil_dir = self.claude_dir.parent / (self.claude_dir.name + "-evil")
+        evil_dir.mkdir()
+        evil_file = evil_dir / "target.jsonl"
+        evil_file.write_text("data")
+
+        list_sessions._remove(evil_file)
+
+        self.assertTrue(
+            evil_file.exists(),
+            "_remove() must refuse paths in sibling dirs that share a string prefix",
+        )
+
+    def test_remove_accepts_legitimate_claude_path(self):
+        """Regression guard: the path-guard fix must not refuse legitimate
+        paths inside ~/.claude/."""
+        legit_file = self.project_root / "legit.jsonl"
+        legit_file.write_text("data")
+
+        list_sessions._remove(legit_file)
+
+        self.assertFalse(
+            legit_file.exists(),
+            "_remove() must still delete legitimate paths under CLAUDE_DIR",
+        )
+
 if __name__ == "__main__":
     unittest.main()

--- a/skills/sessions/tests/test_list_sessions.py
+++ b/skills/sessions/tests/test_list_sessions.py
@@ -312,5 +312,99 @@ class PrunePerformanceTests(unittest.TestCase):
             )
 
 
+class SafetyTests(unittest.TestCase):
+    """Defensive properties: atomic history rewrite + tight path guard in _remove."""
+
+    def setUp(self):
+        import os
+        self._os = os
+
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+        self.claude_dir = Path(self.tmp.name) / ".claude"
+        self.claude_dir.mkdir()
+        (self.claude_dir / "projects").mkdir()
+
+        self.project = "/imaginary/project/path"
+        encoded = "-imaginary-project-path"
+        self.project_root = self.claude_dir / "projects" / encoded
+        self.project_root.mkdir()
+
+        self._claude_patch = patch.object(
+            list_sessions, "CLAUDE_DIR", self.claude_dir,
+        )
+        self._claude_patch.start()
+        self.addCleanup(self._claude_patch.stop)
+
+        # Force the shutil fallback in _remove(); no real Trash interaction.
+        self._sp_patch = patch.object(
+            subprocess, "run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=1),
+        )
+        self._sp_patch.start()
+        self.addCleanup(self._sp_patch.stop)
+
+    # ------------------------------------------------------------------
+    # Atomic history.jsonl rewrite.
+    # ------------------------------------------------------------------
+
+    def test_history_rewrite_uses_os_replace(self):
+        """Rewriting history.jsonl must go through os.replace, not direct write."""
+        uuid = "abc12345-1111-2222-3333-444444444444"
+        _write_session(self.project_root, uuid)
+
+        history = self.claude_dir / "history.jsonl"
+        history.write_text(json.dumps({
+            "project": self.project, "sessionId": uuid, "display": "x",
+        }) + "\n")
+
+        with patch.object(self._os, "replace", wraps=self._os.replace) as spy:
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                list_sessions.delete(uuid, self.project)
+            self.assertEqual(
+                spy.call_count, 1,
+                "history rewrite must call os.replace exactly once",
+            )
+
+    def test_history_rewrite_leaves_no_tmp_file(self):
+        """The .tmp file used during atomic rewrite must be renamed away."""
+        uuid = "abc12345-1111-2222-3333-444444444444"
+        _write_session(self.project_root, uuid)
+
+        history = self.claude_dir / "history.jsonl"
+        history.write_text(json.dumps({
+            "project": self.project, "sessionId": uuid, "display": "x",
+        }) + "\n")
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            list_sessions.delete(uuid, self.project)
+
+        tmp = history.parent / (history.name + ".tmp")
+        self.assertFalse(tmp.exists(), "history.jsonl.tmp must not survive the rewrite")
+        self.assertTrue(history.exists(), "history.jsonl must exist after the rewrite")
+
+    def test_history_rewrite_actually_filters(self):
+        """End-to-end: the deleted UUID's history line is gone after delete."""
+        kept_uuid    = "00000000-0000-0000-0000-000000000001"
+        deleted_uuid = "00000000-0000-0000-0000-000000000002"
+        _write_session(self.project_root, deleted_uuid)
+
+        history = self.claude_dir / "history.jsonl"
+        history.write_text("\n".join([
+            json.dumps({"project": self.project, "sessionId": kept_uuid,    "display": "keep"}),
+            json.dumps({"project": self.project, "sessionId": deleted_uuid, "display": "drop"}),
+        ]) + "\n")
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            list_sessions.delete(deleted_uuid, self.project)
+
+        remaining = history.read_text()
+        self.assertIn(kept_uuid,    remaining)
+        self.assertNotIn(deleted_uuid, remaining)
+
 if __name__ == "__main__":
     unittest.main()

--- a/skills/sessions/tests/test_list_sessions.py
+++ b/skills/sessions/tests/test_list_sessions.py
@@ -1,0 +1,112 @@
+"""Tests for list_sessions.py — selector resolution behavior.
+
+The SKILL.md and README claim that `delete` supports prefix-UUID matching and
+fuzzy-name matching. These tests verify that contract.
+
+Run from the repo root:
+    python3 -m unittest discover -s skills/sessions/tests
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+
+# Load the script as a module so we can call its functions directly.
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "list_sessions.py"
+_spec = importlib.util.spec_from_file_location("list_sessions", _SCRIPT)
+list_sessions = importlib.util.module_from_spec(_spec)
+sys.modules["list_sessions"] = list_sessions
+_spec.loader.exec_module(list_sessions)
+
+
+def _write_session(
+    project_root: Path,
+    uuid: str,
+    custom_title: str | None = None,
+) -> Path:
+    """Create a fake session JSONL plus its sidecar directories."""
+    project_root.mkdir(parents=True, exist_ok=True)
+    jsonl = project_root / f"{uuid}.jsonl"
+
+    lines = []
+    if custom_title:
+        lines.append(json.dumps({
+            "type": "custom-title",
+            "customTitle": custom_title,
+        }))
+    else:
+        lines.append(json.dumps({"type": "user", "content": "hello"}))
+
+    jsonl.write_text("\n".join(lines) + "\n")
+    return jsonl
+
+
+class SelectorResolutionTests(unittest.TestCase):
+    """Verify delete() honors the selector contract documented in SKILL.md."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+        self.claude_dir = Path(self.tmp.name) / ".claude"
+        self.claude_dir.mkdir()
+        (self.claude_dir / "projects").mkdir()
+
+        self.project = "/imaginary/project/path"
+        # Mirrors list_sessions.project_dir() encoding.
+        encoded = "-imaginary-project-path"
+        self.project_root = self.claude_dir / "projects" / encoded
+        self.project_root.mkdir()
+
+        # Point the module at our temp tree.
+        self._claude_patch = patch.object(
+            list_sessions, "CLAUDE_DIR", self.claude_dir,
+        )
+        self._claude_patch.start()
+        self.addCleanup(self._claude_patch.stop)
+
+        # Force _remove()'s shutil fallback by making the trash subprocess
+        # "fail." This keeps tests hermetic — no real Trash interaction.
+        self._sp_patch = patch.object(
+            subprocess, "run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=1),
+        )
+        self._sp_patch.start()
+        self.addCleanup(self._sp_patch.stop)
+
+    def _delete(self, selector: str) -> str:
+        """Run delete() and capture stdout."""
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            list_sessions.delete(selector, self.project)
+        return buf.getvalue()
+
+    # ------------------------------------------------------------------
+    # The headline regression test — proves the SKILL.md claim.
+    # ------------------------------------------------------------------
+
+    def test_delete_by_uuid_prefix(self):
+        """SKILL.md: 'fuzzy name or prefix match'. README: 'delete by partial UUID'."""
+        full_uuid = "42f15ca9-2d23-4ee5-9ad8-17fc6c3637f2"
+        jsonl = _write_session(self.project_root, full_uuid)
+
+        self._delete("42f15ca9")
+
+        self.assertFalse(
+            jsonl.exists(),
+            "delete() with UUID prefix should remove the session",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two small defensive fixes in `delete()`'s side-effects. Both are pre-existing bugs (not introduced by PR #2). One commit per bug for easy cherry-pick.

**Depends on #2.** This branch is based on `fix/selector-resolution`, so the diff against `master` shows all five commits. Only the last two are new to this PR:

- `45c01e1 fix: atomic history.jsonl rewrite`
- `7032b9e fix: tighten _remove() path guard against sibling-dir prefix bypass`

If you merge #2 first, this rebases cleanly. If you'd rather review #3 in isolation, looking at the two commits above (or `git diff fix/selector-resolution..fix/atomic-and-pathguard`) gives the new surface.

## Bug 1 — non-atomic `history.jsonl` rewrite

`_rewrite_history()` does `read_text` → `write_text` on `history.jsonl`. Between those calls, another Claude Code session can append to the file. When our `write_text` lands last, that append is lost. If our write is interrupted (signal, OOM, crash), the file is left half-written.

**Fix:** write filtered contents to `history.jsonl.tmp`, then `os.replace()` onto the target. `os.replace` is atomic on POSIX and Windows for the same-filesystem case, and the `.tmp` file is a sibling so they're always on the same filesystem. ~6 LOC.

Three tests:
- `os.replace` is called exactly once per rewrite (proves mechanism, not just outcome).
- The `.tmp` file is renamed away cleanly (no leak).
- End-to-end: deleted UUID's line gone, kept UUID's line remains.

## Bug 2 — `_remove()` path-guard prefix bypass

`_remove()` guards against unrelated paths with:

```python
if not str(path.resolve()).startswith(str(CLAUDE_DIR.resolve())):
    return
```

This is a **string** prefix check, not a **path containment** check. With `CLAUDE_DIR = /Users/max/.claude`, the path `/Users/max/.claude-evil/foo` passes the guard because there's no separator boundary in the comparison.

Not exploitable today — every call site passes paths derived from `CLAUDE_DIR`. But it's the wrong shape for a safety check on a function that reaches `shutil.rmtree`. Anyone wiring `_remove()` to a user-supplied or env-derived path inherits the bug.

**Fix:** append `os.sep` to `CLAUDE_DIR` before the comparison. `/Users/max/.claude/x` still passes; `/Users/max/.claude-evil/x` is now rejected; `/Users/max/.claude` itself is also rejected (we never want to delete the root). ~2 LOC.

Considered `Path.is_relative_to` (3.9+) but it returns `True` for `CLAUDE_DIR` itself, which is worse semantics here.

Two tests:
- The sibling-dir bypass is refused.
- Legitimate paths inside `CLAUDE_DIR` still get deleted (regression guard).

## Proof

```
$ python3 -m unittest discover -s skills/sessions/tests
.................
Ran 17 tests in 0.048s
OK
```

12 tests carry over from #2, 5 are new in this PR.

## Notes

- Both fixes are defense-in-depth, not correctness fixes for any observed crash. I noticed them while reviewing #2; sending them now while the context is fresh.
- The `_remove()` fix is conservative — explicitly chose `os.sep` over `is_relative_to` to keep `CLAUDE_DIR`-itself-rejected behavior.
- Tests live in the same `SafetyTests` class for one-concern-per-class consistency with #2's structure.